### PR TITLE
refactor: use vercel env variable on staging

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,8 @@
 const config = {
   env: process.env.NODE_ENV,
-  appUrl: process.env.NEXT_PUBLIC_APP_URL,
+  appUrl:
+    process.env.NEXT_PUBLIC_APP_URL ??
+    `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`,
   server: {
     url: process.env.NEXT_PUBLIC_SERVER_URL,
   },


### PR DESCRIPTION
Update config to be able to use vercel staging urls as appUrl